### PR TITLE
fix mssql syntax for adding a column

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,6 +273,33 @@ var MssqlDriver = Base.extend({
     return this.runSql(sql).nodeify(callback);
   },
 
+  addColumn: function(tableName, columnName, columnSpec, callback) {
+    var columnSpec = this.normalizeColumnSpec(columnSpec);
+    this._prepareSpec(columnName, columnSpec, {}, tableName);
+    var def = this.createColumnDef(columnName, columnSpec, {}, tableName);
+    var extensions = '';
+    var self = this;
+
+    if (typeof this._applyAddColumnExtension === 'function') {
+      extensions = this._applyAddColumnExtension(def, tableName, columnName);
+    }
+
+    var sql = util.format(
+      'ALTER TABLE %s ADD %s %s',
+      this.escapeDDL(tableName),
+      def.constraints,
+      extensions
+    );
+
+    return this.runSql(sql)
+      .then(function() {
+        var callbacks = def.callbacks || [];
+        if (def.foreignKey) callbacks.push(def.foreignKey);
+        return self.recurseCallbackArray(callbacks);
+      })
+      .nodeify(callback);
+  },
+
   removeColumn: function (tableName, columnName, callback) {
     var sql = util.format(
       'ALTER TABLE [%s].[%s] DROP COLUMN [%s]',


### PR DESCRIPTION
Db-migrate-base functionality for adding a column errors (ALTER TABLE ADD COLUMN) when trying to run a migration on a mssql table. Syntax should be (ALTER TABLE ADD ...).